### PR TITLE
There is no need for tar to list every file which is extracted.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN         apt-get update && \
 
 ADD         https://download.owncloud.org/community/owncloud-7.0.4.tar.bz2 /tmp/oc.tar.bz2
 RUN         mkdir -p /var/www/owncloud /owncloud /var/log/cron && \
-            tar -C /var/www/ -xvf /tmp/oc.tar.bz2 && \
+            tar -C /var/www/ -xf /tmp/oc.tar.bz2 && \
             chown -R www-data:www-data /var/www/owncloud && \
             rm -rf /var/www/owncloud/config && ln -sf /owncloud /var/www/owncloud/config && \
             chmod +x /usr/bin/bootstrap.sh && \


### PR DESCRIPTION
* The file list is quite long hides the important things of the build.