### PR TITLE
all: make /owncloud uri appendix configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN chmod a+x /var/www/owncloud/apps/extensions.sh ; \
     /var/www/owncloud/apps/extensions.sh /var/www/owncloud/apps/extensions.conf /var/www/owncloud/apps ; \
     rm /var/www/owncloud/apps/extensions.sh /var/www/owncloud/apps/extensions.conf
 
+ENV OWNCLOUD_IN_ROOTPATH 0
 EXPOSE 80
 EXPOSE 443
 

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -50,7 +50,7 @@ http {
           listen 80; 
 
           # Path to the root of your installation
-          root /var/www/;
+          root -x-replace-oc-rootpath-;
 
           client_max_body_size 10G; # set max upload size
           fastcgi_buffers 64 4K;

--- a/configs/nginx_ssl.conf
+++ b/configs/nginx_ssl.conf
@@ -59,7 +59,7 @@ http {
          ssl_certificate_key -x-replace-key-x-; 
 
           # Path to the root of your installation
-          root /var/www/;
+          root -x-replace-oc-rootpath-;
 
           client_max_body_size 10G; # set max upload size
           fastcgi_buffers 64 4K;

--- a/misc/bootstrap.sh
+++ b/misc/bootstrap.sh
@@ -13,6 +13,13 @@ else
     sed -i "s#-x-replace-key-x-#$SSL_KEY#" /root/nginx_ssl.conf
     cp /root/nginx_ssl.conf /etc/nginx/nginx.conf
 fi
+
+if [ "${OWNCLOUD_IN_ROOTPATH}" = "1" ]; then
+    sed -i "s#-x-replace-oc-rootpath-#/var/www/owncloud/#" /etc/nginx/nginx.conf
+else
+    sed -i "s#-x-replace-oc-rootpath-#/var/www/#" /etc/nginx/nginx.conf
+fi
+
 chown -R www-data:www-data /var/www/owncloud /owncloud
 echo "Starting server..\n"
 


### PR DESCRIPTION
The default is as before `/var/www/`. To got the `/owncloud` appendix on the
default root path you have to set `OWNCLOUD_IN_ROOTPATH` variable to
`1`.

Issue: #8

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>