### PR TITLE
Fix CalDAV/CardDAV redirects on custom HTTPS port.

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -58,9 +58,9 @@ http {
         # set max upload size
         fastcgi_buffers 64 4K;
 
-        rewrite ^/caldav(.*)$ /remote.php/caldav$1 redirect;
-        rewrite ^/carddav(.*)$ /remote.php/carddav$1 redirect;
-        rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
+        rewrite ^/caldav(.*)$ $scheme://$http_host/remote.php/caldav$1 redirect;
+        rewrite ^/carddav(.*)$ $scheme://$http_host/remote.php/carddav$1 redirect;
+        rewrite ^/webdav(.*)$ $scheme://$http_host/remote.php/webdav$1 redirect;
 
         index index.php;
         error_page 403 /core/templates/403.php;
@@ -81,8 +81,8 @@ http {
             rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
             rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
 
-            rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-            rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
+            rewrite ^/.well-known/carddav $scheme://$http_host/remote.php/carddav/ redirect;
+            rewrite ^/.well-known/caldav $scheme://$http_host/remote.php/caldav/ redirect;
 
             rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 

--- a/configs/nginx_ssl.conf
+++ b/configs/nginx_ssl.conf
@@ -84,9 +84,9 @@ http {
         client_max_body_size 10G;
         fastcgi_buffers 64 4K;
 
-        rewrite ^/caldav(.*)$ /remote.php/caldav$1 redirect;
-        rewrite ^/carddav(.*)$ /remote.php/carddav$1 redirect;
-        rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
+        rewrite ^/caldav(.*)$ $scheme://$http_host/remote.php/caldav$1 redirect;
+        rewrite ^/carddav(.*)$ $scheme://$http_host/remote.php/carddav$1 redirect;
+        rewrite ^/webdav(.*)$ $scheme://$http_host/remote.php/webdav$1 redirect;
 
         index index.php;
         error_page 403 /core/templates/403.php;
@@ -107,8 +107,8 @@ http {
             rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
             rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
 
-            rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-            rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
+            rewrite ^/.well-known/carddav $scheme://$http_host/remote.php/carddav/ redirect;
+            rewrite ^/.well-known/caldav $scheme://$http_host/remote.php/caldav/ redirect;
 
             rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 


### PR DESCRIPTION
Fix for #41.

Afterwards DAVdroid has no problems discovering CalDAV/CardDAV URLs on an OwnCloud server on a custom HTTPS port.