### PR TITLE
Increase upload size to 16G

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN echo 'env[PATH] = /usr/local/bin:/usr/bin:/bin' >> /etc/php5/fpm/pool.d/www.
 
 ## Increase upload limit to 16G
 RUN sed -ie "s/upload_max_filesize=513M/upload_max_filesize=16G/g" /var/www/owncloud/.user.ini && \
-    sed -ie "s/post_max_size=513M/post_max_size=16G/g" /var/www/owncloud/.user.ini
+    sed -ie "s/post_max_size=513M/post_max_size=16G\\nmax_input_time=21600\\nmax_execution_time=21600\\nrequest_terminate_timeout=21600/g" /var/www/owncloud/.user.ini
 
 ADD configs/cron.conf /etc/oc-cron.conf
 RUN crontab /etc/oc-cron.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ ADD configs/3party_apps.conf configs/nginx_ssl.conf configs/nginx.conf configs/d
 ## Fixed warning in admin panel getenv('PATH') == '' for ownCloud 8.1.
 RUN echo 'env[PATH] = /usr/local/bin:/usr/bin:/bin' >> /etc/php5/fpm/pool.d/www.conf
 
+## Increase upload limit to 16G
+RUN sed -ie "s/upload_max_filesize=513M/upload_max_filesize=16G/g" /var/www/owncloud/.user.ini && \
+    sed -ie "s/post_max_size=513M/post_max_size=16G/g" /var/www/owncloud/.user.ini
+
 ADD configs/cron.conf /etc/oc-cron.conf
 RUN crontab /etc/oc-cron.conf
 

--- a/Makefile
+++ b/Makefile
@@ -135,5 +135,3 @@ owncloud-dev:
 		--volume "$(PWD)/debugging/phpinfo.php:/var/www/owncloud/phpinfo.php" \
 		--env "OWNCLOUD_IN_ROOTPATH=$(docker_owncloud_in_root_path)" \
 		$(image_owncloud)
-		# --volume "$(PWD)/configs/php_uploads.ini:/etc/php5/fpm/conf.d/uploads.ini" \
-		# --volume "$(PWD)/configs/htaccess_uploads:/var/www/owncloud/.htaccess_upload" \

--- a/configs/htaccess_uploads
+++ b/configs/htaccess_uploads
@@ -1,4 +1,0 @@
-php_value upload_max_filesize = 16G
-php_value post_max_size = 16G
-php_value max_input_time 3600
-php_value max_execution_time 3600

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -54,7 +54,7 @@ http {
         # Path to the root of your installation
         root -x-replace-oc-rootpath-;
 
-        client_max_body_size 10G;
+        client_max_body_size 16G;
         # set max upload size
         fastcgi_buffers 64 4K;
 
@@ -90,6 +90,7 @@ http {
         }
 
         location ~ \.php(?:$|/) {
+            fastcgi_read_timeout 21600;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/configs/nginx_ssl.conf
+++ b/configs/nginx_ssl.conf
@@ -81,7 +81,7 @@ http {
         root -x-replace-oc-rootpath-;
 
         ## set max upload size
-        client_max_body_size 10G;
+        client_max_body_size 16G;
         fastcgi_buffers 64 4K;
 
         rewrite ^/caldav(.*)$ $scheme://$http_host/remote.php/caldav$1 redirect;
@@ -116,6 +116,7 @@ http {
         }
 
         location ~ \.php(?:$|/) {
+            fastcgi_read_timeout 21600;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/configs/php_uploads.ini
+++ b/configs/php_uploads.ini
@@ -1,3 +1,0 @@
-php_value[upload_max_filesize] = 10G
-php_value[post_max_size] = 10G
-php_value[max_execution_time] = 3600


### PR DESCRIPTION
Tracked down what owncloud uses to set the max upload size and implemented a 16G upload limit.