### PR TITLE
Fix stupid default permanent storage path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_RUN_OPTIONS ?= --env "TZ=Europe/Berlin"
 docker_owncloud_http_port    ?= 80
 docker_owncloud_https_port   ?= 443
 docker_owncloud_in_root_path ?= 1
-docker_owncloud_permanent_storage ?= /tmp/owncloud
+docker_owncloud_permanent_storage ?= /var/lib/jchaney/owncloud
 docker_owncloud_ssl_cert ?= /etc/ssl/certs/ssl-cert-snakeoil.pem
 docker_owncloud_ssl_key  ?= /etc/ssl/private/ssl-cert-snakeoil.key
 docker_owncloud_servername ?= localhost

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ For running in production, you need to provide a TLS key and certificate. The
 Makefile defaults to `/etc/ssl/private/ssl-cert-snakeoil.key` and
 `/etc/ssl/certs/ssl-cert-snakeoil.pem`. Make sure those files exist or extend
 the Makefile (you can include this Makefile and overwrite some variables in
-your own Makefile). To generate self signed once you can run the following command:
+your own Makefile).
+You might also want to change variables like
+`docker_owncloud_permanent_storage` to define where the persistent data will be
+stored.
+To generate self signed once you can run the following command:
 
 ```Shell
 make-ssl-cert generate-default-snakeoil


### PR DESCRIPTION
As pointed out by @rvetere, `/tmp/owncloud` is one of the worst default
paths for the persistent data of the container created using the
Makefile. What makes this worse is that the documentation did not
mention it.

This default value was chosen in the assumption that everybody would
review at least the commands that are executed by make that would show
that all volumes are bind mounted from `/tmp/`. Of course this
assumption is bad so thanks very much to @rvetere for saying something!

Related to: https://github.com/jchaney/owncloud/issues/58

I will leave this issue open so that people who might have such a setup
running hopefully notice the issue before it is too late.