### PR TITLE
Upgrade to ownCloud 10.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive ;\
         wget
 
 ## Check latest version: https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule
-ENV OWNCLOUD_VERSION="9.1.7" \
+ENV OWNCLOUD_VERSION="10.0.7" \
     OWNCLOUD_IN_ROOTPATH="0" \
     OWNCLOUD_SERVERNAME="localhost"
 


### PR DESCRIPTION
ownCloud 9.1 is EOF as of 2018-03-14. ownCloud 10.0 has not been thoughtfully tested with this image. Maintainer wanted, see #62. It it not yet clear when this will be merged into master.

https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule

Tested:

* Deployment from scratch (sqlite)
* File upload